### PR TITLE
 'dict object' has no attribute

### DIFF
--- a/icinga2-ansible-add-hosts/tasks/icinga2_add_hosts.yml
+++ b/icinga2-ansible-add-hosts/tasks/icinga2_add_hosts.yml
@@ -1,10 +1,12 @@
 ---
+
 - name: Copy Host Definitions
   template: src=hosts_template.j2
-            dest={{ icinga2_hosts_dir }}/{{ hostvars[item]['ansible_fqdn'] }}.conf
+            dest={{ icinga2_hosts_dir }}/{{ ansible_fqdn }}.conf
             owner=root 
             group=root 
             mode=0644
+            backup=yes
   with_items: groups['all']
   notify: 
    - restart icinga2


### PR DESCRIPTION
This fixes the issue when creating the file. 
```yaml
One or more undefined variables: 'dict object' has no attribute error. 
```

Added backup=yes to allow timestamped backups of this file to reduce the risk of configuration loss.

In the template i found another error: 
```
fatal: [icinga2] => {'msg': "AnsibleUndefinedVariable: One or more undefined variables: 'dict object' has no attribute 'ansible_default_ipv4'", 'failed': True}
fatal: [icinga2] => {'msg': 'One or more items failed.', 'failed': True, 'changed': False, 'results': [{'msg': "AnsibleUndefinedVariable: One or more undefined variables: 'dict object' has no attribute 'ansible_default_ipv4'", 'failed': True}]}
```

I will look into this. 

There are more things to change with this playbook. 
- Only the icinga repository is not sufficient, at least on Centos 7 you require epel for some of the installed packages. (since we mirror repositories i have no cut & paste ready config, maybe ill create one later)
- In Centos 7 you get another version of mysql ido, importing the schema path is not working there anymore. 