### PR TITLE
Added Gentoo installation tasks in no-ui and classic-ui roles

### DIFF
--- a/icinga2-ansible-classic-ui/defaults/main.yml
+++ b/icinga2-ansible-classic-ui/defaults/main.yml
@@ -17,3 +17,18 @@ icinga2_classic_ui_rpm:
  - { package: "python-passlib" }
 
 htpasswd_rh: "/etc/icinga/passwd"
+
+# Vars for Gentoo OS Family
+icinga2_classic_ui_ebuilds:
+ - { package: "icinga" }
+ - { package: "passlib" }
+
+# Set which webserver to use, choice between apache2 and lighttpd, set to none if using
+# another webserver, but then you're on your own with configuring the webserver
+icinga2_classic_ui_webserver: 'none'
+
+# Set to file or directory, to tell the playbooks if your package.use is a file or 
+# directory
+icinga2_classic_ui_gentoo_package_use: 'file'
+
+htpasswd_gentoo: "/etc/icinga/htpasswd"

--- a/icinga2-ansible-classic-ui/tasks/icinga2_classic_ui_Gentoo_install.yml
+++ b/icinga2-ansible-classic-ui/tasks/icinga2_classic_ui_Gentoo_install.yml
@@ -1,0 +1,51 @@
+---
+- name: Set web USE-flag on Icinga to enable Classic UI
+  lineinfile: dest=/etc/portage/package.use
+              create=yes
+              line="net-analyzer/icinga web"
+              state=present
+  when: icinga2_classic_ui_gentoo_package_use == 'file'
+
+- name: Set web USE-flag on Icinga to enable Classic UI
+  lineinfile: dest=/etc/portage/package.use/icinga2-classic-ui
+              create=yes
+              line="net-analyzer/icinga web"
+              state=present
+  when: icinga2_classic_ui_gentoo_package_use == 'directory'
+
+- name: Set apache2 USE-flag on Icinga to enable apache2 configs installation
+  replace: dest=/etc/portage/package.use
+           regexp="(net-analyzer/icinga.*)"
+           replace="\1 apache2"
+  when: icinga2_classic_ui_gentoo_package_use == 'file' and icinga2_classic_ui_webserver == 'apache2'
+
+- name: Set web USE-flag on Icinga to enable lighttpd configs installation
+  replace: dest=/etc/portage/package.use/icinga2-classic-ui
+           regexp="(net-analyzer/icinga.*)"
+           replace="\1 lighttpd"
+  when: icinga2_classic_ui_gentoo_package_use == 'directory' and icinga2_classic_ui_webserver == 'lighttpd'
+
+- name: Install Icinga Classic UI on Gentoo OS family
+  portage: package={{ item.package }}
+           state=present
+  with_items: icinga2_classic_ui_ebuilds
+
+- name: Configure password for icingaadmin user
+  htpasswd: name=icingaadmin
+            state=present
+            path="{{ htpasswd_gentoo }}"
+            create=yes
+            password="{{ icinga2_classic_ui_passwd }}"
+
+- name: restart apache2
+  service: name=apache2
+           state=restarted
+  when: icinga2_classic_ui_webserver == 'apache2'
+
+- name: restart lighthttpd
+  service: name=apache2
+           state=restarted
+  when: icinga2_classic_ui_webserver == 'lighthttpd'
+
+- name: Icinga Classic UI Installation finished (Gentoo)
+  debug: msg="User icingaadmin and password {{ icinga2_classic_ui_passwd }} have been created. If you enabled apache2 or lighttpd USE-flags you can access it at http://IP/, otherwise you have to configure your webserver of choice yourself."

--- a/icinga2-ansible-classic-ui/tasks/main.yml
+++ b/icinga2-ansible-classic-ui/tasks/main.yml
@@ -6,3 +6,6 @@
 
 - include: icinga2_classic_ui_RedHat_install.yml
   when: ansible_os_family == 'RedHat'
+
+- include: icinga2_classic_ui_Gentoo_install.yml
+  when: ansible_os_family == 'Gentoo'

--- a/icinga2-ansible-no-ui/tasks/icinga2_Gentoo_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Gentoo_install.yml
@@ -1,0 +1,9 @@
+---
+- name: Install Icinga2 on Gentoo OS family
+  portage: package={{ item.package }} state=present
+  with_items: icinga2_pkg
+
+- name: Start Icinga2
+  service: name=icinga2
+           state=started
+           enabled=yes

--- a/icinga2-ansible-no-ui/tasks/main.yml
+++ b/icinga2-ansible-no-ui/tasks/main.yml
@@ -7,6 +7,9 @@
 - include: icinga2_RedHat_install.yml
   when: ansible_os_family == 'RedHat'
 
+- include: icinga2_Gentoo_install.yml
+  when: ansible_os_family == 'Gentoo'
+
 - include: icinga2_configure.yml
   tags: 
    - icinga2_configure


### PR DESCRIPTION
Added the installation tasks for installing icinga2 and classic ui on a gentoo based system. Added a few variables to steer how it is installed, with USE-flags, so that the user gets the choice of getting the right webserver files installed for them automatically.