### PR TITLE
Add python-mysqldb package

### DIFF
--- a/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
+++ b/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
@@ -1,4 +1,7 @@
 ---
+- name: Install Mysql prerequisite
+  apt: name=python-mysqldb
+
 - name: Install Icinga2 IDO modules on Debian family
   apt: name=icinga2-ido-mysql
        state=latest


### PR DESCRIPTION
Add prerequisite due to this error:

`FAILED! => {"changed": false, "failed": true, "msg": "the python mysqldb module is required"}`