### PR TITLE
Reload icinga2 for host definition change

### DIFF
--- a/icinga2-ansible-add-hosts/handlers/main.yml
+++ b/icinga2-ansible-add-hosts/handlers/main.yml
@@ -5,3 +5,8 @@
   service: name=icinga2
            state=restarted
            enabled=yes
+
+- name: reload icinga2
+  service: name=icinga2
+           state=reloaded
+           enabled=yes

--- a/icinga2-ansible-add-hosts/tasks/icinga2_add_hosts.yml
+++ b/icinga2-ansible-add-hosts/tasks/icinga2_add_hosts.yml
@@ -7,4 +7,4 @@
             mode=0644
   with_items: "{{ groups['all'] }}"
   notify:
-   - restart icinga2
+   - reload icinga2


### PR DESCRIPTION
No restart is needed when changing host definition. `reload` sends SIGHUP, which is enough for Icinga 2.