### PR TITLE
Object logic extensions

### DIFF
--- a/icinga2-ansible-add-hosts/README.md
+++ b/icinga2-ansible-add-hosts/README.md
@@ -25,6 +25,8 @@ Example Playbook
      icinga_host_attributes:
        check_command: "http"
        vars.sla: "24x7"
+     icinga_host_templates:
+       - icinga/sensors.j2
      host_checks: |
        object Service "load_average" {
          host_name = "{{ hostvars[item]['ansible_fqdn'] }}"
@@ -39,6 +41,22 @@ Example Playbook
        }
      tags: add-hosts
 
+```
+
+The `icinga_host_templates` allows you to inject more complex
+`host_variables` through a template.
+In this example, you would add `templatse/icinga/sensors.j2`, e.g.
+
+```
+vars.sensors = {
+    {% for sensor in hostvars[item].sensors %}
+    "Sensor {{ sensor.name }}" = {
+        sensor_name = "{{ sensor.name }}"
+        cpu_temp_crit = {{ sensor.critical }}
+        cpu_temp_warn = {{ sensor.warning }}
+    },
+    {% endfor %}
+}
 ```
 
 Role Variables

--- a/icinga2-ansible-add-hosts/README.md
+++ b/icinga2-ansible-add-hosts/README.md
@@ -22,9 +22,9 @@ Example Playbook
   roles:
    - role: icinga2-ansible-add-hosts
      configuration_logic: "object"
-     host_attributes: |
-       check_command = "http"
-       vars.sla = "24x7"
+     icinga_host_attributes:
+       check_command: "http"
+       vars.sla: "24x7"
      host_checks: |
        object Service "load_average" {
          host_name = "{{ hostvars[item]['ansible_fqdn'] }}"

--- a/icinga2-ansible-add-hosts/templates/object_logic.j2
+++ b/icinga2-ansible-add-hosts/templates/object_logic.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 {% if hostvars[item]['group_names'] | difference('monitoring_servers') %}
   # A host definition
 object Host "{{ hostvars[item]['ansible_fqdn'] }}" {
@@ -11,6 +13,14 @@ object Host "{{ hostvars[item]['ansible_fqdn'] }}" {
   {% if 'icinga_host_attributes' in hostvars[item] %}
     {% for attribute, value in hostvars[item].icinga_host_attributes.iteritems() %}
     {{ attribute }} = {{ value }}
+    {% endfor %}
+  {% endif %}
+
+  {% if 'icinga_host_templates' in hostvars[item] %}
+    {% for template in hostvars[item].icinga_host_templates %}
+      {% include template %}
+      # Intentional newline
+
     {% endfor %}
   {% endif %}
 }

--- a/icinga2-ansible-add-hosts/templates/object_logic.j2
+++ b/icinga2-ansible-add-hosts/templates/object_logic.j2
@@ -8,6 +8,11 @@ object Host "{{ hostvars[item]['ansible_fqdn'] }}" {
 
   {{ host_attributes }}
 
+  {% if 'icinga_host_attributes' in hostvars[item] %}
+    {% for attribute, value in hostvars[item].icinga_host_attributes.iteritems() %}
+    {{ attribute }} = {{ value }}
+    {% endfor %}
+  {% endif %}
 }
 
   #Here Goes Checks if Any


### PR DESCRIPTION
- Adds a more `ansible`-like `icinga_hosts_attributes` variable (which allows variables to be declared in `yaml`, instead of plain icinga2 config syntax)
- Adds the possibility to template out more complex attributes via `host_templates`:

The `icinga_host_templates` allows you to inject more complex
`host_variables` through a template.
In this example, you would add `templatse/icinga/sensors.j2`, e.g.

```
- hosts: monitoring_servers
  roles:
   - role: icinga2-ansible-add-hosts
     configuration_logic: "object"
     icinga_host_templates:
       - icinga/sensors.j2
```

```
vars.sensors = {
    {% for sensor in hostvars[item].sensors %}
    "Sensor {{ sensor.name }}" = {
        sensor_name = "{{ sensor.name }}"
        cpu_temp_crit = {{ sensor.critical }}
        cpu_temp_warn = {{ sensor.warning }}
    },
    {% endfor %}
}
```

Together with an ansible facts library that gathers information from `lm_sensors`, this automatically injects all possible sensor data into the Icinga host configuration.