### PR TITLE
Simpler condition without obsolete Jinja markup

### DIFF
--- a/icinga2-ansible-no-ui/tasks/icinga2_configure.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_configure.yml
@@ -6,7 +6,7 @@
             owner=root
             group=root
             mode=0644
-  when: "{{ icinga2_conf_global | default('') | length}}"
+  when: icinga2_conf_global is defined
   notify:
    - restart icinga2
 
@@ -17,6 +17,6 @@
             owner=root
             group=root
             mode=0644
-  when: "{{ check_commands | default('') | length}}"
+  when: check_commands is defined
   notify:
    - restart icinga2


### PR DESCRIPTION
Ansible 2.3 warns that the "when:" clauses should not contain Jinja markup.
It's also not necessary to test the length of the empty string, we just need to check if the variable is defined.