### PR TITLE
Make IDO config optional for web2

### DIFF
--- a/icinga2-ansible-web2-ui/defaults/main.yml
+++ b/icinga2-ansible-web2-ui/defaults/main.yml
@@ -8,7 +8,6 @@ icinga2_web_mysql_schema_rh: "/usr/share/icinga2-ido-mysql/schema/mysql.sql"
 icinga2_web_mysql_schema_debian: "/usr/share/icinga2-ido-mysql/schema/mysql.sql"
 
 icinga2_ido_mysql_conf: "/etc/icinga2/features-available/ido-mysql.conf"
-icinga2_ido_mysql_configuration: "none"
 
 icinga2_web2_db: "icingaweb"
 icinga2_web2_db_pass: "icingaweb"

--- a/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
+++ b/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
@@ -30,6 +30,7 @@
             owner=nagios
             group=nagios
             mode=0640
+  when: icinga2_ido_mysql_configuration is defined
 
 - name: Enable Icinga2 Ido Mysql Feature
   command: "icinga2 feature enable ido-mysql"

--- a/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_RedHat_install.yml
+++ b/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_RedHat_install.yml
@@ -33,6 +33,7 @@
             owner=icinga
             group=icinga
             mode=0640
+  when: icinga2_ido_mysql_configuration is defined
 
 - name: Enable Icinga2 Ido Mysql Feature
   command: "icinga2 feature enable ido-mysql"


### PR DESCRIPTION
The package already provides a default configuration, we have no reason to force a new one if there is no need from the users's point if view