### PR TITLE
Provide option to not use public yum repo

### DIFF
--- a/icinga2-ansible-no-ui/defaults/main.yml
+++ b/icinga2-ansible-no-ui/defaults/main.yml
@@ -14,6 +14,7 @@ icinga2_pkg:
  - { package: "nagios-plugins" }
  - { package: "bsd-mailx" }
 
+icinga2_use_public_yum_repo: True
 icinga2_url_yum: "https://packages.icinga.org/epel/ICINGA-release.repo"
 icinga2_url_yum_fedora: "https://packages.icinga.org/fedora/ICINGA-release.repo"
 icinga2_repo_yum: "/etc/yum.repos.d/ICINGA-release.repo"

--- a/icinga2-ansible-no-ui/tasks/icinga2_RedHat_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_RedHat_install.yml
@@ -1,16 +1,19 @@
 ---
-- name: Get Icinga2 Yum Key on RedHat OS family
-  rpm_key: key={{ icinga2_key }}
-           state=present
+- name: Get Public Yum Repo
+  block:
+    - name: Get Icinga2 Yum Key on RedHat OS family
+      rpm_key: key={{ icinga2_key }}
+               state=present
 
-- name: Get Icinga2 Yum Repo on RedHat OS family (Fedora)
-  get_url: url='{{ icinga2_url_yum_fedora }}'
-           dest={{ icinga2_repo_yum }}
-  when: ansible_distribution == 'Fedora'
+    - name: Get Icinga2 Yum Repo on RedHat OS family (Fedora)
+      get_url: url='{{ icinga2_url_yum_fedora }}'
+               dest={{ icinga2_repo_yum }}
+      when: ansible_distribution == 'Fedora'
 
-- name: Get Icinga2 Yum Repo on RedHat OS family
-  get_url: url='{{ icinga2_url_yum }}'
-           dest={{ icinga2_repo_yum }}
+    - name: Get Icinga2 Yum Repo on RedHat OS family
+      get_url: url='{{ icinga2_url_yum }}'
+               dest={{ icinga2_repo_yum }}
+  when: icinga2_use_public_yum_repo
 
 - name: Install Icinga2 on RedHat OS family
   yum: name={{ item.package }}


### PR DESCRIPTION
Anyone using their own repos should be able to have the option of not installing a public repo on their servers.  This provides that simple flag.