### PR TITLE
Fixing with_item variable wrapping to support ansible 2.2+'s requirement

### DIFF
--- a/icinga2-ansible-classic-ui/tasks/icinga2_classic_ui_Debian_install.yml
+++ b/icinga2-ansible-classic-ui/tasks/icinga2_classic_ui_Debian_install.yml
@@ -1,10 +1,10 @@
 ---
 - name: Install Icinga Classic UI on Debian OS family
-  apt: pkg={{ item.package }} 
+  apt: pkg={{ item.package }}
        state=latest
        update_cache=yes
        cache_valid_time=30
-  with_items: icinga2_classic_ui_pkg
+  with_items: "{{ icinga2_classic_ui_pkg }}"
 
 - name: Configure a password for icingaadmin user
   htpasswd: name=icingaadmin
@@ -12,7 +12,7 @@
             path={{ htpasswd_deb }}
             create=no
             password={{ icinga2_classic_ui_passwd }}
-  notify: 
+  notify:
    - restart apache2
 
 - name: Icinga Classic UI Installation finished (Debian)

--- a/icinga2-ansible-classic-ui/tasks/icinga2_classic_ui_Gentoo_install.yml
+++ b/icinga2-ansible-classic-ui/tasks/icinga2_classic_ui_Gentoo_install.yml
@@ -28,7 +28,7 @@
 - name: Install Icinga Classic UI on Gentoo OS family
   portage: package={{ item.package }}
            state=present
-  with_items: icinga2_classic_ui_ebuilds
+  with_items: "{{ icinga2_classic_ui_ebuilds }}"
 
 - name: Configure password for icingaadmin user
   htpasswd: name=icingaadmin

--- a/icinga2-ansible-classic-ui/tasks/icinga2_classic_ui_RedHat_install.yml
+++ b/icinga2-ansible-classic-ui/tasks/icinga2_classic_ui_RedHat_install.yml
@@ -2,7 +2,7 @@
 - name: Install Icinga Classic UI on RedHat OS family
   yum: name={{ item.package }}
        state=latest
-  with_items: icinga2_classic_ui_rpm
+  with_items: "{{ icinga2_classic_ui_rpm }}"
   notify:
    - restart icinga2
    - restart httpd

--- a/icinga2-ansible-web-ui/tasks/icinga2_web_ui_RedHat_install.yml
+++ b/icinga2-ansible-web-ui/tasks/icinga2_web_ui_RedHat_install.yml
@@ -9,7 +9,7 @@
 - name: Install Icinga Web on RedHat OS family
   yum: name={{ item.package }}
        state=latest
-  with_items: icinga2_web_ui_rpm
+  with_items: "{{ icinga2_web_ui_rpm }}"
 
 - name: Create a Database for Icinga Web
   mysql_db: name={{ icinga2_web_db_dbuser }}

--- a/icinga2-ansible-web-ui/tasks/icinga2_web_ui_mysql_RedHat_install.yml
+++ b/icinga2-ansible-web-ui/tasks/icinga2_web_ui_mysql_RedHat_install.yml
@@ -2,7 +2,7 @@
 - name: Install MariaDB and Utils on Red Hat OS Family (based on your choice in icinga2_web_ui_ido value)
   yum: name={{ item.package }}
        state=latest
-  with_items: icinga2_web_ui_mariadb_rpm
+  with_items: "{{ icinga2_web_ui_mariadb_rpm }}"
   when: ansible_distribution_major_version == "7"
 
 - name: Start MariaDB


### PR DESCRIPTION
Not properly wrapping with_item with `"{ }"` results in an error as seen here:  https://github.com/ansible/ansible/issues/23496

There is still one here that I wasn't able since jinja2 doesn't support nested variables: https://github.com/pallets/jinja/issues/623  :
```
icinga2-ansible-web-ui/tasks/icinga2_web_ui_mysql_RedHat_install.yml
17:  with_items: icinga2_web_ui_{{ icinga2_web_ui_ido }}_rpm
```

Cheers