### PR TITLE
a block can't have a name

### DIFF
--- a/icinga2-ansible-no-ui/tasks/icinga2_RedHat_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_RedHat_install.yml
@@ -1,6 +1,5 @@
 ---
-- name: Get Public Yum Repo
-  block:
+- block:
     - name: Get Icinga2 Yum Key on RedHat OS family
       rpm_key: key={{ icinga2_key }}
                state=present


### PR DESCRIPTION
When running this Playbook, I see the following error:
```
ERROR! 'name' is not a valid attribute for a Block

The error appears to have been in '<...>icinga2-ansible/icinga2-ansible-no-ui/tasks/icinga2_RedHat_install.yml': line 2, column 3, but may                                                                                               
be elsewhere in the file depending on the exact syntax problem.                                                                                                                                                                                                                

The offending line appears to be:                                                                                                                                                                                                                                              

---                                                                                                                                                                                                                                                                            
- name: Get Public Yum Repo                                                                                                                                                                                                                                                    
  ^ here         
```                                                                                                                                                                                                                                                              

This PR simply removes the "name", and just leaves the "block".